### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,11 +1,12 @@
 {
     "name": "While True Script",
     "type": "app",
+    "instance_version": "6.15.60",
     "categories": [
         "development"
     ],
     "description": "Used to create infinite task for debug",
-    "docker_image": "supervisely/development:0.0.1",
+    "docker_image": "supervisely/development:6.73.564",
     "main_script": "src/main.py",
     "task_location": "application_sessions",
     "isolate": true,

--- a/config.json
+++ b/config.json
@@ -1,39 +1,39 @@
 {
-    "name": "While True Script",
-    "type": "app",
-    "instance_version": "6.15.60",
-    "categories": [
-        "development"
-    ],
-    "description": "Used to create infinite task for debug",
-    "docker_image": "supervisely/development:6.73.564",
-    "main_script": "src/main.py",
-    "task_location": "application_sessions",
-    "isolate": true,
-    "integrated_into": [
-        "standalone",
-        "image_annotation_tool"
-    ],
-    "icon": "https://img.icons8.com/color/96/000000/infinity.png",
-    "icon_background": "#FFFFFF",
-    "session_tags": [
-        "deployed_nn",
-        "deployed_nn_cls",
-        "deployed_nn_3d",
-        "sly_video_tracking",
-        "sly_smart_annotation",
-        "deployed_nn_embeddings",
-        "sly_point_cloud_tracking",
-        "deployed_nn_recommendations",
-        "labeling_jobs",
-        "sly_interpolation"
-    ],
-    "allowed_shapes": [
-        "polygon",
-        "point",
-        "rectangle",
-        "graph",
-        "line",
-        "bitmap"
-    ]
+  "name": "While True Script",
+  "type": "app",
+  "instance_version": "6.15.60",
+  "categories": [
+    "development"
+  ],
+  "description": "Used to create infinite task for debug",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "main_script": "src/main.py",
+  "task_location": "application_sessions",
+  "isolate": true,
+  "integrated_into": [
+    "standalone",
+    "image_annotation_tool"
+  ],
+  "icon": "https://img.icons8.com/color/96/000000/infinity.png",
+  "icon_background": "#FFFFFF",
+  "session_tags": [
+    "deployed_nn",
+    "deployed_nn_cls",
+    "deployed_nn_3d",
+    "sly_video_tracking",
+    "sly_smart_annotation",
+    "deployed_nn_embeddings",
+    "sly_point_cloud_tracking",
+    "deployed_nn_recommendations",
+    "labeling_jobs",
+    "sly_interpolation"
+  ],
+  "allowed_shapes": [
+    "polygon",
+    "point",
+    "rectangle",
+    "graph",
+    "line",
+    "bitmap"
+  ]
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.55
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
